### PR TITLE
Split configuration into several tabs

### DIFF
--- a/front/config.form.php
+++ b/front/config.form.php
@@ -35,32 +35,32 @@ if (!$plugin->isActivated('flyvemdm')) {
    Html::displayNotFoundError();
 }
 
-Session::checkRight("flyvemdm:flyvemdm", PluginFlyvemdmProfile::RIGHT_FLYVEMDM_USE);
-Session::checkRight("config", UPDATE);
+Session::checkRight('flyvemdm:flyvemdm', PluginFlyvemdmProfile::RIGHT_FLYVEMDM_USE);
+Session::checkRight('config', UPDATE);
 
-$plugin = new Plugin();
 $config = new Config();
 $pluginConfig = new PluginFlyvemdmConfig();
 if (isset($_POST["update"])) {
    $config->update($_POST);
-   Html::back();
+   //Html::back();
+   Html::redirect(Toolbox::getItemTypeFormURL(PluginFlyvemdmConfig::class));
 } else if (isset($_POST['addDocTypes'])) {
    $pluginConfig->addDocumentTypes();
-   Html::back();
+   Html::redirect(Toolbox::getItemTypeFormURL(PluginFlyvemdmConfig::class));
 } else {
    // Header
 
    Html::header(
       __('Configuration'),
       '',
-      'config',
-      'plugin',
-      "flyvemdm"
+      'admin',
+      'PluginFlyvemdmMenu',
+      'config'
    );
-   $pluginConfig->showForm();
+   $pluginConfig->display(['id' => 1]);
    // Footer
 
-   if (strstr($_SERVER['PHP_SELF'], "popup")) {
+   if (strstr($_SERVER['PHP_SELF'], 'popup')) {
       Html::popFooter();
    } else {
       Html::footer();

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -129,10 +129,8 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
 
    /**
     * Define tabs available for this itemtype
-    * @see CommonGLPI::defineTabs()
     */
    public function defineTabs($options = []) {
-      //  TODO : fluent interface in GLPI 9.2 + when GLPI 9.1 dropped
       $tab = [];
       $this->addDefaultFormTab($tab);
       $this->addStandardTab(PluginFlyvemdmGeolocation::class, $tab, $options);
@@ -151,7 +149,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
     * @param int $withtemplate
     * @return array|string
     */
-   function getTabNameForItem(CommonGLPI $item, $withtemplate=0) {
+   function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
       if (static::canView()) {
          switch ($item->getType()) {
@@ -184,7 +182,7 @@ class PluginFlyvemdmAgent extends CommonDBTM implements PluginFlyvemdmNotifiable
     *
     * @return bool
     */
-   static function displayTabContentForItem(CommonGLPI $item, $tabnum=1, $withtemplate=0) {
+   static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
       switch (get_class($item)) {
          case static::class:
             self::showDangerZone($item);

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -85,37 +85,41 @@ class PluginFlyvemdmMenu extends CommonGLPI {
 
       $twig = plugin_flyvemdm_getTemplateEngine();
       $data = [
-            'menu'   => [
-                  __('General', 'flyvemdm') => [
-                        PluginFlyvemdmInvitation::getTypeName($pluralNumber)  => [
-                              'link' =>Toolbox::getItemTypeSearchURL(PluginFlyvemdmInvitation::class),
-                              'pic'  => PluginFlyvemdmInvitation::getMenuPicture(),
-                        ],
-                        PluginFlyvemdmAgent::getTypeName($pluralNumber)       => [
-                              'link' => Toolbox::getItemTypeSearchURL(PluginFlyvemdmAgent::class),
-                              'pic'  => PluginFlyvemdmAgent::getMenuPicture(),
-                        ],
-                        PluginFlyvemdmFleet::getTypeName($pluralNumber)       => [
-                              'link' =>Toolbox::getItemTypeSearchURL(PluginFlyvemdmFleet::class),
-                              'pic'  => PluginFlyvemdmFleet::getMenuPicture(),
-                        ],
-                        PluginFlyvemdmPackage::getTypeName($pluralNumber)     => [
-                              'link' => Toolbox::getItemTypeSearchURL(PluginFlyvemdmPackage::class),
-                              'pic'  => PluginFlyvemdmPackage::getMenuPicture(),
-                        ],
-                        PluginFlyvemdmFile::getTypeName($pluralNumber)        => [
-                              'link' =>Toolbox::getItemTypeSearchURL(PluginFlyvemdmFile::class),
-                              'pic'  => PluginFlyvemdmFile::getMenuPicture(),
-                        ],
+         'menu'   => [
+            __('General', 'flyvemdm') => [
+                  PluginFlyvemdmInvitation::getTypeName($pluralNumber)  => [
+                        'link' =>Toolbox::getItemTypeSearchURL(PluginFlyvemdmInvitation::class),
+                        'pic'  => PluginFlyvemdmInvitation::getMenuPicture(),
                   ],
-                  /*
-                  __('Board', 'flyvemdm') => [
-                        PluginFlyvemdmFleet::getTypeName($pluralNumber)       => [
-                              'link' => Toolbox::getItemTypeSearchURL(PluginFlyvemdmFleet::class)
-                        ]
-                  ]
-                  */
+                  PluginFlyvemdmAgent::getTypeName($pluralNumber)       => [
+                        'link' => Toolbox::getItemTypeSearchURL(PluginFlyvemdmAgent::class),
+                        'pic'  => PluginFlyvemdmAgent::getMenuPicture(),
+                  ],
+                  PluginFlyvemdmFleet::getTypeName($pluralNumber)       => [
+                        'link' =>Toolbox::getItemTypeSearchURL(PluginFlyvemdmFleet::class),
+                        'pic'  => PluginFlyvemdmFleet::getMenuPicture(),
+                  ],
+                  PluginFlyvemdmPackage::getTypeName($pluralNumber)     => [
+                        'link' => Toolbox::getItemTypeSearchURL(PluginFlyvemdmPackage::class),
+                        'pic'  => PluginFlyvemdmPackage::getMenuPicture(),
+                  ],
+                  PluginFlyvemdmFile::getTypeName($pluralNumber)        => [
+                        'link' =>Toolbox::getItemTypeSearchURL(PluginFlyvemdmFile::class),
+                        'pic'  => PluginFlyvemdmFile::getMenuPicture(),
+                  ],
             ],
+            __('Configuration', 'flyvemdm') => [
+               __('General')       => [
+                  'link' => Toolbox::getItemTypeFormURL(PluginFlyvemdmConfig::class) . '?forcetab='.PluginFlyvemdmConfig::class.'$1',
+               ],
+               __('Message queue', 'flyvemdm') => [
+                  'link' => Toolbox::getItemTypeFormURL(PluginFlyvemdmConfig::class) . '?forcetab='.PluginFlyvemdmConfig::class.'$2',
+               ],
+               __('Debug', 'flyvemdm') => [
+                  'link' => Toolbox::getItemTypeFormURL(PluginFlyvemdmConfig::class) . '?forcetab='.PluginFlyvemdmConfig::class.'$3',
+               ]
+            ]
+         ],
       ];
       echo $twig->render('menu.html', $data);
    }

--- a/tpl/config-debug.html
+++ b/tpl/config-debug.html
@@ -1,0 +1,45 @@
+<table class="tab_cadre_fixe" cellpadding="5">
+   <tbody>
+      <tr>
+         <th colspan="3" class="">{{ __('Enrollment', 'flyvemdm') }}</th>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Enable explicit enrolment failures', 'flyvemdm') }}</td>
+         <td>{{ config.debug_enrolment|raw }}</td>
+         <td></td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Disable token expiration on successful enrolment', 'flyvemdm') }}</td>
+         <td>{{ config.debug_noexpire|raw }}</td>
+         <td></td>
+      </tr>
+      <tr>
+         <th colspan="3" class="">{{ __('Bug collector', 'flyvemdm') }}</th>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Android bug collector URL', 'flyvemdm') }}</td>
+         <td><input type="text" name="android_bugcollecctor_url" value="{{ config.android_bugcollecctor_url }}"></td>
+         <td>{{ __('https://bugreport.flyvemdm.com/path/to/service', 'flyvemdm') }}</td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Android bug collector user', 'flyvemdm') }}</td>
+         <td><input type="text" name="android_bugcollector_login"
+            value="{{ config.android_bugcollector_login }}"></td>
+         <td></td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Android bug collector password', 'flyvemdm') }}</td>
+         <td><input type="password" name="android_bugcollector_passwd"
+            value="{{ config.android_bugcollector_passwd }}" placeholder="{{ config.android_bugcollector_passwd_placeholder }}"></td>
+         <td></td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td class="center" colspan="2">
+            <input type="hidden" name="id" value="1" class="submit">
+            <input type="hidden" name="config_context" value="flyvemdm">
+            <input type="hidden" name="config_class" value="PluginFlyvemdmConfig">
+            <input type="submit" name="update" value="{{ __('Save') }}" class="submit">
+         </td>
+      </tr>
+   </tbody>
+</table>

--- a/tpl/config-messagequeue.html
+++ b/tpl/config-messagequeue.html
@@ -1,0 +1,68 @@
+<table class="tab_cadre_fixe" cellpadding="5">
+   <tbody>
+      <tr>
+         <th colspan="3" class="">{{ __('MQTT broker', 'flyvemdm') }}</th>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('MQTT broker address', 'flyvemdm') }}</td>
+         <td><input type="text" name="mqtt_broker_address" value="{{ config.mqtt_broker_address }}"></td>
+         <td>{{ __('An IP address or a hostname', 'flyvemdm') }}</td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('MQTT broker internal address', 'flyvemdm') }}</td>
+         <td><input type="text" name="mqtt_broker_internal_address"
+            value="{{ config.mqtt_broker_internal_address }}"></td>
+         <td>{{ __('An IP address or a hostname', 'flyvemdm') }}</td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('MQTT broker port', 'flyvemdm') }}</td>
+         <td><input type="number" name="mqtt_broker_port" value="{{ config.mqtt_broker_port }}"
+            min="1" max="65535"></td>
+         <td>{{ __('A port number between 1025 and 65535, usually 1883 or 8883', 'flyvemdm') }}</td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Use TLS', 'flyvemdm') }}</td>
+         <td>{{ config.mqtt_broker_tls|raw }}
+         </td>
+         <td></td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('CA certificate', 'flyvemdm') }}</td>
+         <td>{{ config.CACertificateFile|raw }}</td>
+         <td></td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Cipher suite (TLS enabled)', 'flyvemdm') }}</td>
+         <td><input type="text" name="mqtt_broker_tls_ciphers"
+            value="{{ config.mqtt_broker_tls_ciphers }}"></td>
+         <td>{{ __('Mqtt broker cipher suite', 'flyvemdm') }}</td>
+      </tr>
+      <tr class="">
+         <td>test</td>
+         <td><input type="button" id="pluginFlyvemdm-mqtt-test"
+            name="mqtt-test" value="{{ __('test', 'flyvemdm') }}" class="submit"><span
+            id="pluginFlyvemdm-test-feedback"></span></td>
+      </tr>
+      <tr>
+         <th colspan="3" class="">{{ __('Client certificate server (Broker MQTT with TLS enabled)', 'flyvemdm') }}</th>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Use client certificates', 'flyvemdm') }}</td>
+         <td>{{ config.mqtt_use_client_cert|raw }}</td>
+         <td></td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td>{{ __('Ssl certificate server for MQTT clients', 'flyvemdm') }}</td>
+         <td><input type="text" name="ssl_cert_url" value="{{ config.ssl_cert_url }}"></td>
+         <td>{{ __('https://cert.domain.com/path/to/service', 'flyvemdm') }}</td>
+      </tr>
+      <tr class="tab_bg_1">
+         <td class="center" colspan="2">
+            <input type="hidden" name="id" value="1" class="submit">
+            <input type="hidden" name="config_context" value="flyvemdm">
+            <input type="hidden" name="config_class" value="PluginFlyvemdmConfig">
+            <input type="submit" name="update" value="{{ __('Save') }}" class="submit">
+         </td>
+      </tr>
+   </tbody>
+</table>

--- a/tpl/config.html
+++ b/tpl/config.html
@@ -1,10 +1,7 @@
-<table class="tab_cadre" cellpadding="5">
+<table class="tab_cadre_fixe" cellpadding="5">
    <tbody>
       <tr>
-         <th colspan="3" class="">{{ __('Flyve MDM settings', 'flyvemdm') }}</th>
-      </tr>
-      <tr>
-         <th colspan="3" class="">{{ __('Easy configuration', 'flyvemdm') }}</th>
+         <th colspan="3" class="">{{ __('Document types', 'flyvemdm') }}</th>
       </tr>
       <tr class="tab_bg_1">
          <td>{{ __('Allow upload of APK and UPK files', 'flyvemdm') }}</td>
@@ -25,95 +22,6 @@
       <tr class="tab_bg_1">
          <td>{{ __('Account type for the devices', 'flyvemdm') }}</td>
          <td>{{ config.agentusercategories_id|raw }}</td>
-         <td></td>
-      </tr>
-      <tr>
-         <th colspan="3" class="">{{ __('MQTT broker', 'flyvemdm') }}</th>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('MQTT broker address', 'flyvemdm') }}</td>
-         <td><input type="text" name="mqtt_broker_address" value="{{ config.mqtt_broker_address }}"></td>
-         <td>{{ __('An IP address or a hostname', 'flyvemdm') }}</td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('MQTT broker internal address', 'flyvemdm') }}</td>
-         <td><input type="text" name="mqtt_broker_internal_address"
-            value="{{ config.mqtt_broker_internal_address }}"></td>
-         <td>{{ __('An IP address or a hostname', 'flyvemdm') }}</td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('MQTT broker port', 'flyvemdm') }}</td>
-         <td><input type="number" name="mqtt_broker_port" value="{{ config.mqtt_broker_port }}"
-            min="1" max="65535"></td>
-         <td>{{ __('A port number between 1025 and 65535, usually 1883 or 8883', 'flyvemdm') }}</td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Use TLS', 'flyvemdm') }}</td>
-         <td>{{ config.mqtt_broker_tls|raw }}
-         </td>
-         <td></td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('CA certificate', 'flyvemdm') }}</td>
-         <td>{{ config.CACertificateFile|raw }}</td>
-         <td></td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Cipher suite (TLS enabled)', 'flyvemdm') }}</td>
-         <td><input type="text" name="mqtt_broker_tls_ciphers"
-            value="{{ config.mqtt_broker_tls_ciphers }}"></td>
-         <td>{{ __('Mqtt broker cipher suite', 'flyvemdm') }}</td>
-      </tr>
-      <tr class="">
-         <td>test</td>
-         <td><input type="button" id="pluginFlyvemdm-mqtt-test"
-            name="mqtt-test" value="{{ __('test', 'flyvemdm') }}" class="submit"><span
-            id="pluginFlyvemdm-test-feedback"></span></td>
-      </tr>
-      <tr>
-         <th colspan="3" class="">{{ __('Client certificate server (Broker MQTT with TLS enabled)', 'flyvemdm') }}</th>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Use client certificates', 'flyvemdm') }}</td>
-         <td>{{ config.mqtt_use_client_cert|raw }}</td>
-         <td></td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Ssl certificate server for MQTT clients', 'flyvemdm') }}</td>
-         <td><input type="text" name="ssl_cert_url" value="{{ config.ssl_cert_url }}"></td>
-         <td>{{ __('https://cert.domain.com/path/to/service', 'flyvemdm') }}</td>
-      </tr>
-      <tr>
-         <th colspan="3" class="">{{ __('Debug mode', 'flyvemdm') }}</th>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Enable explicit enrolment failures', 'flyvemdm') }}</td>
-         <td>{{ config.debug_enrolment|raw }}</td>
-         <td></td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Disable token expiration on successful enrolment', 'flyvemdm') }}</td>
-         <td>{{ config.debug_noexpire|raw }}</td>
-         <td></td>
-      </tr>
-      <tr>
-         <th colspan="3" class="">{{ __('Bug collector', 'flyvemdm') }}</th>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Android bug collector URL', 'flyvemdm') }}</td>
-         <td><input type="text" name="android_bugcollecctor_url" value="{{ config.android_bugcollecctor_url }}"></td>
-         <td>{{ __('https://bugreport.flyvemdm.com/path/to/service', 'flyvemdm') }}</td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Android bug collector user', 'flyvemdm') }}</td>
-         <td><input type="text" name="android_bugcollector_login"
-            value="{{ config.android_bugcollector_login }}"></td>
-         <td></td>
-      </tr>
-      <tr class="tab_bg_1">
-         <td>{{ __('Android bug collector password', 'flyvemdm') }}</td>
-         <td><input type="password" name="android_bugcollector_passwd"
-            value="{{ config.android_bugcollector_passwd }}" placeholder="{{ config.android_bugcollector_passwd_placeholder }}"></td>
          <td></td>
       </tr>
       <tr>


### PR DESCRIPTION
Divide the configuration of the plugin into several subpages

This prepares the UI to provide more settings in an organized UI. We can consider adding an assistant to help the admin to setup the whole solution with snippets of configuration files.

![image](https://user-images.githubusercontent.com/14139801/32148677-f5513790-bcfa-11e7-910e-8db877227c86.png)

![image](https://user-images.githubusercontent.com/14139801/32148682-05ed47ec-bcfb-11e7-8b63-9d3d70694e83.png)

closes #152