### PR TITLE
shift received datetime to server's timezone

### DIFF
--- a/inc/mqtthandler.class.php
+++ b/inc/mqtthandler.class.php
@@ -246,7 +246,10 @@ class PluginFlyvemdmMqtthandler extends \sskaje\mqtt\MessageHandler {
       if ($agent->getByTopic($topic)) {
          $position = json_decode($message, true);
          if (isset($position['datetime'])) {
-            $dateGeolocation = \DateTime::createFromFormat('U', $position['datetime']);
+            // The datetime sent by the device is expected to be on UTC timezone
+            $dateGeolocation = \DateTime::createFromFormat('U', $position['datetime'], new \DateTimeZone("UTC"));
+            // Shift the datetime to the timezone of the server
+            $dateGeolocation->setTimezone(date_default_timezone_get());
          } else {
             $dateGeolocation = false;
          }


### PR DESCRIPTION
A datetime received by the agent is expected to be in UTC timezone. We need to shift it to the server's timezone before saving it.