### PR TITLE
Scan requests when the apk does not change

### DIFF
--- a/inc/package.class.php
+++ b/inc/package.class.php
@@ -304,9 +304,10 @@ class PluginFlyvemdmPackage extends CommonDBTM {
                $task->updateQueue($fleet, $policy->getGroup());
             }
          }
-      }
 
-      $this->createOrionReport();
+         // File updated, then scan it again
+         $this->createOrionReport();
+      }
    }
 
    /**


### PR DESCRIPTION
If an update occurs on a package but the APK remains  the same, a analyze  request is sent to Orion. It is useless. Let's scan only on an update of the APK file.