### PR TITLE
Fix misordered list

### DIFF
--- a/tests/suite-integration/PluginFlyvemdmAgent.php
+++ b/tests/suite-integration/PluginFlyvemdmAgent.php
@@ -86,7 +86,7 @@ class PluginFlyvemdmAgent extends CommonTestCase {
     * @tags testEnrollAgent
     */
    public function testEnrollAgent() {
-      list($user, $guestEmail, $invitation, $serial) = $this->createUserInvitation(\User::getForeignKeyField());
+      list($user, $serial, $guestEmail, $invitation) = $this->createUserInvitation(\User::getForeignKeyField());
 
       $invitationToken = $invitation->getField('invitation_token');
       $inviationId = $invitation->getID();


### PR DESCRIPTION
A unit test fails. Here is the fix. This is only a misordered vars in the list.